### PR TITLE
JI-5488 Ensure that viewState is always defined

### DIFF
--- a/src/scripts/h5p-sort-paragraphs-content.js
+++ b/src/scripts/h5p-sort-paragraphs-content.js
@@ -1025,6 +1025,11 @@ export default class SortParagraphsContent {
    * @param {string|number} newState State to set.
    */
   setViewState(newState) {
+    // Fallback to 'task'
+    if (newState === undefined) {
+      newState = 0;
+    }
+
     if (typeof newState === 'number') {
       newState = Object.entries(this.viewStates).find((entry) => {
         return entry[1] === newState;

--- a/src/scripts/h5p-sort-paragraphs-content.js
+++ b/src/scripts/h5p-sort-paragraphs-content.js
@@ -31,7 +31,7 @@ export default class SortParagraphsContent {
     this.oldOrder = null; // Old order when dragging
 
     this.viewStates = this.params.viewStates;
-    this.setViewState(params.previousState?.viewState);
+    this.setViewState(this.params.previousState?.viewState);
 
     // Original position of selected draggable
     this.selectedDraggable = null;
@@ -1022,14 +1022,9 @@ export default class SortParagraphsContent {
 
   /**
    * Set view state.
-   * @param {string|number} newState State to set.
+   * @param {string|number} [newState] State to set, defaulting to 'task'.
    */
-  setViewState(newState) {
-    // Fallback to 'task'
-    if (newState === undefined) {
-      newState = 0;
-    }
-
+  setViewState(newState = 0) {
     if (typeof newState === 'number') {
       newState = Object.entries(this.viewStates).find((entry) => {
         return entry[1] === newState;


### PR DESCRIPTION
On newly created content, params.previousState would be read as null (despite using Utils.extend), causing this.viewState to be undefined. This caused all forms of navigation using click or keyboard to be broken and unusable. 