### PR TITLE
JI-5492 — Sort paragraphs state not fully reset

### DIFF
--- a/src/scripts/h5p-sort-paragraphs.js
+++ b/src/scripts/h5p-sort-paragraphs.js
@@ -305,6 +305,7 @@ export default class SortParagraphs extends H5P.Question {
    * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-5}
    */
   resetTask() {
+    this.previousState = {};
     this.removeFeedback();
     this.content.reset();
     this.setViewState('task');

--- a/src/scripts/h5p-sort-paragraphs.js
+++ b/src/scripts/h5p-sort-paragraphs.js
@@ -305,9 +305,9 @@ export default class SortParagraphs extends H5P.Question {
    * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-5}
    */
   resetTask() {
-    this.previousState = {};
     this.removeFeedback();
     this.content.reset();
+    this.previousState = {};
     this.setViewState('task');
     this.trigger('resize');
   }


### PR DESCRIPTION
Seems that when resetTask is triggered, it wasn't emptying the previous state 