### PR TITLE
JI-5487 Prevent duplicate aria reading

### DIFF
--- a/src/scripts/h5p-sort-paragraphs-content.js
+++ b/src/scripts/h5p-sort-paragraphs-content.js
@@ -841,11 +841,6 @@ export default class SortParagraphsContent {
 
     // Set ARIA label
     paragraph.setAriaLabel(Util.stripHTML(ariaLabel));
-
-    // ARIA label changed, but that's not a state - will not re-announce
-    if (['grabbed', 'dropped'].indexOf(options.action) !== -1) {
-      this.callbacks.read(Util.stripHTML(ariaLabel));
-    }
   }
 
   /**


### PR DESCRIPTION
It seems that the updated aria-label is in fact read naturally, causing the 'grabbed' and 'dropped' messages to be read twice.